### PR TITLE
Add User Agent and HTTP_ACCEPT to recognisable session table

### DIFF
--- a/app/controllers/devise_recognisable/sessions_controller.rb
+++ b/app/controllers/devise_recognisable/sessions_controller.rb
@@ -39,7 +39,8 @@ class DeviseRecognisable::SessionsController < Devise::SessionsController
       DeviseRecognisable::RecognisableSession.create!(
         recognisable: resource_class.find_by(email: self.resource.email),
         sign_in_ip: request.location.ip,
-        sign_in_at: Time.now
+        sign_in_at: Time.now,
+        user_agent: request.user_agent,
       )
     end
   end
@@ -50,7 +51,8 @@ class DeviseRecognisable::SessionsController < Devise::SessionsController
     DeviseRecognisable::RecognisableSession.create!(
       recognisable: resource_class.find_by(email: params[resource_name][:email]),
       sign_in_ip: request.location.ip,
-      sign_in_at: Time.now
+      sign_in_at: Time.now,
+      user_agent: request.user_agent,
     )
   end
 end

--- a/app/controllers/devise_recognisable/sessions_controller.rb
+++ b/app/controllers/devise_recognisable/sessions_controller.rb
@@ -41,6 +41,7 @@ class DeviseRecognisable::SessionsController < Devise::SessionsController
         sign_in_ip: request.location.ip,
         sign_in_at: Time.now,
         user_agent: request.user_agent,
+        accept_header: request.headers["HTTP_ACCEPT"]
       )
     end
   end
@@ -53,6 +54,7 @@ class DeviseRecognisable::SessionsController < Devise::SessionsController
       sign_in_ip: request.location.ip,
       sign_in_at: Time.now,
       user_agent: request.user_agent,
+      accept_header: request.headers["HTTP_ACCEPT"]
     )
   end
 end

--- a/app/controllers/devise_recognisable/sessions_controller.rb
+++ b/app/controllers/devise_recognisable/sessions_controller.rb
@@ -2,10 +2,10 @@ require 'geocoder'
 
 class DeviseRecognisable::SessionsController < Devise::SessionsController
   prepend_before_action :check_for_authentication_token, only: :new
-  prepend_before_action :perform_ip_check, only: :create
+  prepend_before_action :perform_recognition_check, only: :create
   append_after_action :store_recognisable_details, only: :create
  
-  def perform_ip_check
+  def perform_recognition_check
     # Find the user
     self.resource = resource_class.find_by(email: params[resource_name][:email])
     previous_session = Devise.ref('DeviseRecognisable::RecognisableSession').get

--- a/app/controllers/devise_recognisable/sessions_controller.rb
+++ b/app/controllers/devise_recognisable/sessions_controller.rb
@@ -13,17 +13,7 @@ class DeviseRecognisable::SessionsController < Devise::SessionsController
 
     return unless self.resource && previous_session.present?
 
-    # Is the user's IP different to the last one?
-    # Is it more than a certain distance from the last successful sign in?
-    #
-    # NOTE: Geocoder's location method might not be the safest?
-    # See https://github.com/alexreisner/geocoder#geocoding-http-requests
-    last_sign_in = Geocoder.search(previous_session.sign_in_ip).first
-    current_sign_in = Geocoder.search(request.location.ip).first
-    # NOTE: looks like sometimes the current_sign_in isn't a real thing?
-    distance = Geocoder::Calculations.distance_between(last_sign_in&.coordinates, current_sign_in&.coordinates)
-
-    if previous_session.sign_in_ip != request.location.ip or distance > Devise.max_ip_distance
+    unless Recogniser.recognise?(request, previous_session)
       # Don't sign the user in, return them to the sign in screen with a flash
       # message.
       set_flash_message(:alert, :send_new_ip_instructions)

--- a/app/lib/generators/devise_recognisable/install_template.rb
+++ b/app/lib/generators/devise_recognisable/install_template.rb
@@ -5,6 +5,7 @@ class CreateRecognisableSessions < <%= migration_parent %>
       t.integer :recognisable_id
       t.string :sign_in_ip
       t.string :user_agent
+      t.string :accept_header
       t.datetime :sign_in_at
     end
     add_index :recognisable_sessions, [:recognisable_type, :recognisable_id], :name => 'recognisable_index'

--- a/app/lib/generators/devise_recognisable/install_template.rb
+++ b/app/lib/generators/devise_recognisable/install_template.rb
@@ -4,6 +4,7 @@ class CreateRecognisableSessions < <%= migration_parent %>
       t.string :recognisable_type
       t.integer :recognisable_id
       t.string :sign_in_ip
+      t.string :user_agent
       t.datetime :sign_in_at
     end
     add_index :recognisable_sessions, [:recognisable_type, :recognisable_id], :name => 'recognisable_index'

--- a/app/lib/recogniser.rb
+++ b/app/lib/recogniser.rb
@@ -1,0 +1,25 @@
+class Recogniser
+  # Checks 
+  def self.recognise?(request, previous_session)
+    score = 0
+    # Is the user's IP different to the last one?
+    # Is it more than a certain distance from the last successful sign in?
+    #
+    # NOTE: Geocoder's location method might not be the safest?
+    # See https://github.com/alexreisner/geocoder#geocoding-http-requests
+    last_sign_in = Geocoder.search(previous_session.sign_in_ip).first
+    current_sign_in = Geocoder.search(request.location.ip).first
+    # NOTE: looks like sometimes the current_sign_in isn't a real thing?
+    distance = Geocoder::Calculations.distance_between(last_sign_in&.coordinates, current_sign_in&.coordinates)
+    if previous_session.sign_in_ip == request.location.ip or distance < Devise.max_ip_distance
+      score += 1
+    end
+
+    # Is the user's User Agent different to the last one?
+    if previous_session.user_agent == request.user_agent
+      score += 1
+    end
+
+    score > 1
+  end
+end

--- a/app/lib/recogniser.rb
+++ b/app/lib/recogniser.rb
@@ -1,7 +1,14 @@
 class Recogniser
-  # Checks 
+  @@required_scores = {
+    relaxed: 0,
+    normal: 1,
+    strict: 2
+  }
+
+  # Checks the current request against the details from the previous sign in.
   def self.recognise?(request, previous_session)
     score = 0
+
     # Is the user's IP different to the last one?
     # Is it more than a certain distance from the last successful sign in?
     #
@@ -16,15 +23,11 @@ class Recogniser
     end
 
     # Is the user's User Agent is different to the previous signin?
-    if previous_session.user_agent == request.user_agent
-      score += 1
-    end
+    score += 1 if previous_session.user_agent == request.user_agent
 
     # Is the user's Accept header is different to the previous signin?
-    if previous_session.accept_header == request.headers["HTTP_ACCEPT"]
-      score += 1
-    end
+    score += 1 if previous_session.accept_header == request.headers["HTTP_ACCEPT"]
 
-    score > 2
+    score > @@required_scores[Devise.security_level]
   end
 end

--- a/app/lib/recogniser.rb
+++ b/app/lib/recogniser.rb
@@ -15,11 +15,16 @@ class Recogniser
       score += 1
     end
 
-    # Is the user's User Agent different to the last one?
+    # Is the user's User Agent is different to the previous signin?
     if previous_session.user_agent == request.user_agent
       score += 1
     end
 
-    score > 1
+    # Is the user's Accept header is different to the previous signin?
+    if previous_session.accept_header == request.headers["HTTP_ACCEPT"]
+      score += 1
+    end
+
+    score > 2
   end
 end

--- a/app/lib/recogniser.rb
+++ b/app/lib/recogniser.rb
@@ -1,3 +1,5 @@
+# A Class that is responsible for recognising a request by comparing the request
+# to previous sign ins.
 class Recogniser
   @@required_scores = {
     relaxed: 0,
@@ -22,10 +24,10 @@ class Recogniser
       score += 1
     end
 
-    # Is the user's User Agent is different to the previous signin?
+    # Is the user's User Agent is different to the previous sign in?
     score += 1 if previous_session.user_agent == request.user_agent
 
-    # Is the user's Accept header is different to the previous signin?
+    # Is the user's Accept header is different to the previous sign in?
     score += 1 if previous_session.accept_header == request.headers["HTTP_ACCEPT"]
 
     score > @@required_scores[Devise.security_level]

--- a/lib/devise-recognisable.rb
+++ b/lib/devise-recognisable.rb
@@ -16,8 +16,21 @@ module Devise
   #
   #   config.max_ip_distance = 50 # => Sign in attempts from IPs further than
   #   50 miles from the last signin will need to log in via email.
-  mattr_accessor :max_ip_distance
+  mattr_accessor :max_ip_distance, :security_level
   @@max_ip_distance = 100
+
+  # Public: Security level set the strictness of Devise Recognisable (default: :normal).
+  # :strict  requires users to sign in unless all the recognisable details of
+  #          the request match the previous signin.
+  # :normal  requires users to sign in if more than 1 of the recognisable
+  #          details of the request match the previous signin.
+  # :relaxed requires users to sign in if more than 2 of the recognisable
+  #          details of the request match the previous signin.
+  #
+  # Set this in the Devise configuration file (in config/initializers/devise.rb).
+  #
+  #   config.security_level = :strict
+  @@security_level = :normal
 
 end
 

--- a/spec/dummy-app/config/initializers/devise.rb
+++ b/spec/dummy-app/config/initializers/devise.rb
@@ -292,6 +292,7 @@ Devise.setup do |config|
   # end
 
   # ==> Configuration for :registerable
+  config.security_level = :strict
 
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.

--- a/spec/dummy-app/db/migrate/20200929121553_create_recognisable_sessions.rb
+++ b/spec/dummy-app/db/migrate/20200929121553_create_recognisable_sessions.rb
@@ -4,6 +4,7 @@ class CreateRecognisableSessions < ActiveRecord::Migration[5.2]
       t.string :recognisable_type
       t.integer :recognisable_id
       t.string :sign_in_ip
+      t.string :user_agent
       t.datetime :sign_in_at
     end
     add_index :recognisable_sessions, [:recognisable_type, :recognisable_id], :name => 'recognisable_index'

--- a/spec/dummy-app/db/migrate/20200929150408_create_recognisable_sessions.rb
+++ b/spec/dummy-app/db/migrate/20200929150408_create_recognisable_sessions.rb
@@ -5,6 +5,7 @@ class CreateRecognisableSessions < ActiveRecord::Migration[5.2]
       t.integer :recognisable_id
       t.string :sign_in_ip
       t.string :user_agent
+      t.string :accept_header
       t.datetime :sign_in_at
     end
     add_index :recognisable_sessions, [:recognisable_type, :recognisable_id], :name => 'recognisable_index'

--- a/spec/dummy-app/db/schema.rb
+++ b/spec/dummy-app/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_29_121553) do
+ActiveRecord::Schema.define(version: 2020_09_29_150408) do
 
   create_table "recognisable_sessions", force: :cascade do |t|
     t.string "recognisable_type"
     t.integer "recognisable_id"
     t.string "sign_in_ip"
     t.string "user_agent"
+    t.string "accept_header"
     t.datetime "sign_in_at"
     t.index ["recognisable_type", "recognisable_id"], name: "recognisable_index"
   end

--- a/spec/dummy-app/db/schema.rb
+++ b/spec/dummy-app/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_29_111443) do
+ActiveRecord::Schema.define(version: 2020_09_29_121553) do
 
   create_table "recognisable_sessions", force: :cascade do |t|
     t.string "recognisable_type"
     t.integer "recognisable_id"
     t.string "sign_in_ip"
+    t.string "user_agent"
     t.datetime "sign_in_at"
     t.index ["recognisable_type", "recognisable_id"], name: "recognisable_index"
   end

--- a/spec/dummy-app/spec/features/sign_in_spec.rb
+++ b/spec/dummy-app/spec/features/sign_in_spec.rb
@@ -79,60 +79,59 @@ RSpec.feature "Sign in" do
         visit_in_email('Log in')
         expect(page).to have_content('Home sweet home')
       end
+    end
+  end
 
+  context 'from a device with a different User Agent' do
+    let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
+    let!(:new_user_agent) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko)' }
+
+    before do
+      recognisable_session.update!(user_agent: new_user_agent)
+      visit '/'
+      click_link 'Log in'
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Log in'
     end
 
-    context 'from a device with a different User Agent' do
-      let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
-      let!(:new_user_agent) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko)' }
-
-      before do
-        recognisable_session.update!(user_agent: new_user_agent)
-        visit '/'
-        click_link 'Log in'
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: user.password
-        click_button 'Log in'
-      end
-
-      it 'does not log the user in' do
-        expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
-        expect(page).to_not have_content('Home sweet home')
-      end
-
-      context 'visiting the link in the email' do
-        it 'logs the user in' do
-          open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
-          visit_in_email('Log in')
-          expect(page).to have_content('Home sweet home')
-        end
-      end
+    it 'does not log the user in' do
+      expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
+      expect(page).to_not have_content('Home sweet home')
     end
 
-    context 'from a device with a different Accept header value' do
-      let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
-      let!(:new_accept_header) { 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8' }
-
-      before do
-        recognisable_session.update!(accept_header: new_accept_header)
-        visit '/'
-        click_link 'Log in'
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: user.password
-        click_button 'Log in'
+    context 'visiting the link in the email' do
+      it 'logs the user in' do
+        open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
+        visit_in_email('Log in')
+        expect(page).to have_content('Home sweet home')
       end
+    end
+  end
 
-      it 'does not log the user in' do
-        expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
-        expect(page).to_not have_content('Home sweet home')
-      end
+  context 'from a device with a different Accept header value' do
+    let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
+    let!(:new_accept_header) { 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8' }
 
-      context 'visiting the link in the email' do
-        it 'logs the user in' do
-          open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
-          visit_in_email('Log in')
-          expect(page).to have_content('Home sweet home')
-        end
+    before do
+      recognisable_session.update!(accept_header: new_accept_header)
+      visit '/'
+      click_link 'Log in'
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Log in'
+    end
+
+    it 'does not log the user in' do
+      expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
+      expect(page).to_not have_content('Home sweet home')
+    end
+
+    context 'visiting the link in the email' do
+      it 'logs the user in' do
+        open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
+        visit_in_email('Log in')
+        expect(page).to have_content('Home sweet home')
       end
     end
   end

--- a/spec/dummy-app/spec/features/sign_in_spec.rb
+++ b/spec/dummy-app/spec/features/sign_in_spec.rb
@@ -3,10 +3,20 @@ require 'rails_helper'
 RSpec.feature "Sign in" do
   let(:email) { FFaker::Internet.email }
   let(:password) { FFaker::Internet.password }
+  let!(:user) { FactoryBot.create :user }
+
+  let!(:user_agent) { 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36' }
+  let!(:recognisable_session_values) {{
+    recognisable_id: user.id,
+    recognisable_type: 'User',
+    user_agent: user_agent
+  }}
+
+  before do
+    Capybara.current_session.driver.header('User-Agent', user_agent)
+  end
 
   context 'as a user that has no last_sign_in_ip' do
-    let!(:user) { FactoryBot.create :user }
-
     it 'works and does not send an email' do
       visit '/'
       expect(page).to have_content 'Welcome to my website'
@@ -44,8 +54,7 @@ RSpec.feature "Sign in" do
   end
 
   context 'from a different IP' do
-    let!(:user) { FactoryBot.create :user }
-    let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_id: user.id, recognisable_type: 'User' }
+    let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
 
     before do
       recognisable_session.update(sign_in_ip: FFaker::Internet.ip_v4_address)
@@ -68,6 +77,33 @@ RSpec.feature "Sign in" do
         expect(page).to have_content('Home sweet home')
       end
 
+    end
+
+    context 'from a device with a different User Agent' do
+      let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
+      let!(:new_user_agent) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko)' }
+
+      before do
+        recognisable_session.update!(user_agent: new_user_agent)
+        visit '/'
+        click_link 'Log in'
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: user.password
+        click_button 'Log in'
+      end
+
+      it 'does not log the user in' do
+        expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
+        expect(page).to_not have_content('Home sweet home')
+      end
+
+      context 'visiting the link in the email' do
+        it 'logs the user in' do
+          open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
+          visit_in_email('Log in')
+          expect(page).to have_content('Home sweet home')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- The User Agent and HTTP_ACCEPT headers are now stored when users sign in.
- Both are also compared for recognition on sign in.
- Finally, the `security_level` can be set to `:strict`, `:normal` or `:relaxed`.