### PR TITLE
Info only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ config.debug_mode = true
 _N.B. Debug mode only works in a production environment, so to actually log the
 output to Rollbar you will need to deploy your app._
 
+## Info_only mode
+
+You can run DeviseRecognisable in `info_only` mode which turns
+devise_recongise __off__. In `info_only` mode, if devise_recognise does not
+recognise the login request source, it logs the request details, but does not
+require the user to click a link in their email.
+
+To run DeviseRecognisable in `info_only` mode, you need to add the following line
+to your app's Devise initializer file, `./config/initializers/devise.rb`.
+
+```ruby
+config.info_only = true
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/app/controllers/devise_recognisable/sessions_controller.rb
+++ b/app/controllers/devise_recognisable/sessions_controller.rb
@@ -16,18 +16,22 @@ class DeviseRecognisable::SessionsController < Devise::SessionsController
     return if previous_sessions.none?
 
     guard = DeviseRecognisable::Guard.with(request)
+
     unless guard.recognise?(previous_sessions)
-      # Don't sign the user in, return them to the sign in screen with a flash
-      # message.
-      set_flash_message(:alert, :send_new_ip_instructions)
-      redirect_to new_session_path(resource_class)
+      # Skip if running in info_only mode
+      unless Devise.info_only
+        # Don't sign the user in, return them to the sign in screen with a flash
+        # message.
+        set_flash_message(:alert, :send_new_ip_instructions)
+        redirect_to new_session_path(resource_class)
 
-      # Send an email to the user with a sign in link containing a unique
-      # token that is valid for 5 minutes.
-      resource_class.send_new_ip_email(resource_params)
+        # Send an email to the user with a sign in link containing a unique
+        # token that is valid for 5 minutes.
+        resource_class.send_new_ip_email(resource_params)
+      end
 
-      # Debug mode only
-      if Devise.debug_mode && Rails.env.production?
+      # debug or info_only mode
+      if (Devise.debug_mode || Devise.info_only) && Rails.env.production?
         require 'rollbar'
         Rollbar.debug(guard.failures, 'Unrecognised request')
       end

--- a/app/lib/devise_recognisable/guard.rb
+++ b/app/lib/devise_recognisable/guard.rb
@@ -69,7 +69,7 @@ class DeviseRecognisable::Guard
     distance < Devise.max_ip_distance
   end
 
-  # Debug mode only: Returns a results object that contains the relevant
+  # debug or info_only modes: Returns a results object that contains the relevant
   # information on which conditions failed.
   def failures
     failures = {

--- a/lib/devise-recognisable.rb
+++ b/lib/devise-recognisable.rb
@@ -38,6 +38,13 @@ module Devise
   # production.
   mattr_accessor :debug_mode
   @@debug_mode = false
+
+  # Debug: Information only mode. Turns devise_recongise __off__. If
+  # devise_recognise does not recognise the login request source, it logs the
+  # request details, but does not require the user to click a link
+  # in their email.
+  mattr_accessor :info_only
+  @@info_only = false
 end
 
 Devise.add_module :recognisable, model: 'devise-recognisable/model'


### PR DESCRIPTION
- Add a mode that does not redirect the user if they aren't recognised, but does log the results of the Recognition analysis.