### PR TITLE
use the Levenshtein distance for User Agent comparison

### DIFF
--- a/app/lib/devise_recognisable/guard.rb
+++ b/app/lib/devise_recognisable/guard.rb
@@ -1,6 +1,12 @@
+require "damerau-levenshtein"
+
 # A Class that is responsible for recognising a request by comparing the request
 # to previous sign ins.
 class DeviseRecognisable::Guard
+  # NOTE: I've set this to 0 for now so we can observe the Levenshtein distances
+  # in debug_mode. We can set it to an appropriate value when we have more data.
+  MAX_LEVENSHTEIN_DISTANCE = Rails.env.test? ? 10 : 0
+
   @@required_scores = {
     relaxed: 0,
     normal: 1,
@@ -46,7 +52,7 @@ class DeviseRecognisable::Guard
     score += 1 if compare_ip_addresses(session.sign_in_ip)
 
     # Is the request's User Agent different to the session's sign in?
-    score += 1 if session.user_agent == @request.user_agent
+    score += 1 if compare_user_agents(session.user_agent)
 
     # Is the request's Accept header different to the previous sign in?
     score += 1 if session.accept_header == @request.headers["HTTP_ACCEPT"]
@@ -68,6 +74,17 @@ class DeviseRecognisable::Guard
     distance = Geocoder::Calculations.distance_between(previous_sign_in&.coordinates, current_sign_in&.coordinates)
     
     distance < Devise.max_ip_distance
+  end
+
+  # Method to check if the user agent strings are similar. Uses the Levenshtein
+  # distance to calculate the minumum number of changes required to make an
+  # exact match. Takes a session user agent string and returns a bool.
+  def compare_user_agents(session_user_agent)
+    return true if session_user_agent == @request.user_agent
+
+    distance = DamerauLevenshtein.distance(@request.user_agent, session_user_agent, 0)
+
+    distance < MAX_LEVENSHTEIN_DISTANCE
   end
 
   # debug or info_only modes: Returns a results object that contains the relevant
@@ -92,10 +109,15 @@ class DeviseRecognisable::Guard
     end
 
     # Is the request's User Agent different to the session's sign in?
-    unless @closest_match[:session].user_agent == @request.user_agent
+    unless compare_user_agents(@closest_match[:session].user_agent)
       failures[:failures][:user_agent] = {
         request_value: @request.user_agent,
-        session_value: @closest_match[:session].user_agent
+        session_value: @closest_match[:session].user_agent,
+        levenshtein_distance: DamerauLevenshtein.distance(
+          @request.user_agent,
+          @closest_match[:session].session_user_agent,
+          0
+        )
       }
     end
 

--- a/app/lib/devise_recognisable/guard.rb
+++ b/app/lib/devise_recognisable/guard.rb
@@ -82,6 +82,10 @@ class DeviseRecognisable::Guard
   def compare_user_agents(session_user_agent)
     return true if session_user_agent == @request.user_agent
 
+    # DamerauLevenshtein.distance() takes two strings and a optional
+    # argument. The optional argument specifies which algorithm should
+    # be used to calculate the distance between the two strings.
+    # Here we pass in 0 to use the Levenshtein distance.
     distance = DamerauLevenshtein.distance(@request.user_agent, session_user_agent, 0)
 
     distance < MAX_LEVENSHTEIN_DISTANCE
@@ -113,6 +117,10 @@ class DeviseRecognisable::Guard
       failures[:failures][:user_agent] = {
         request_value: @request.user_agent,
         session_value: @closest_match[:session].user_agent,
+        # DamerauLevenshtein.distance() takes two strings and a optional
+        # argument. The optional argument specifies which algorithm should
+        # be used to calculate the distance between the two strings.
+        # Here we pass in 0 to use the Levenshtein distance.
         levenshtein_distance: DamerauLevenshtein.distance(
           @request.user_agent,
           @closest_match[:session].session_user_agent,

--- a/devise-recognisable.gemspec
+++ b/devise-recognisable.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "devise"
   spec.add_dependency "jwt"
   spec.add_dependency "geocoder"
+  spec.add_dependency 'damerau-levenshtein', '~> 1.1'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/spec/dummy-app/Gemfile.lock
+++ b/spec/dummy-app/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ../..
   specs:
     devise-recognisable (0.1.0)
+      damerau-levenshtein (~> 1.1)
       devise
       geocoder
       jwt
@@ -70,6 +71,7 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    damerau-levenshtein (1.3.3)
     devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)

--- a/spec/dummy-app/spec/factories/recognisable_session.rb
+++ b/spec/dummy-app/spec/factories/recognisable_session.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:recognisable_session, :class => DeviseRecognisable::RecognisableSession) do
-    sign_in_ip { FFaker::Internet.ip_v4_address }
+    sign_in_ip { "127.0.0.1" }
     sign_in_at { Time.now - 1.hour }
   end
 end

--- a/spec/dummy-app/spec/features/sign_in_spec.rb
+++ b/spec/dummy-app/spec/features/sign_in_spec.rb
@@ -207,6 +207,26 @@ RSpec.feature "Sign in" do
     end
   end
 
+  context 'from a device with User Agent that is only slightly different' do
+    let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
+    # Change the Chrome build number by one
+    let!(:new_user_agent) { user_agent.gsub(/78.0.3904.108/, '78.0.3904.109') }
+
+    before do
+      recognisable_session.update!(user_agent: new_user_agent)
+      visit '/'
+      click_link 'Log in'
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Log in'
+    end
+
+    it 'logs the user in' do
+      expect(page).to have_content 'Home sweet home'
+      expect(page).to have_content('Signed in successfully')
+    end
+  end
+
   context 'from a device with a different Accept header value' do
     let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
     let!(:new_accept_header) { 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8' }


### PR DESCRIPTION
Currently, when we compare user agent strings, we require an exact match.
This is results in a lot of failures to recognise users when a small change has been made to the user agent string e.g. Chrome has been updated.

So in this PR, we determine the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) between the two user agent strings. If the Levenshtein distance is less than the `MAX_LEVENSHTEIN_DISTANCE`, Devise::Recognisable will "recognise" the user agent string, even if it is not an exact match.