### PR TITLE
Assess ip_addresses by comparing the host and network octets

### DIFF
--- a/app/lib/devise_recognisable/guard.rb
+++ b/app/lib/devise_recognisable/guard.rb
@@ -82,7 +82,7 @@ class DeviseRecognisable::Guard
   def compare_user_agents(session_user_agent)
     return true if session_user_agent == @request.user_agent
 
-    # DamerauLevenshtein.distance() takes two strings and a optional
+    # DamerauLevenshtein.distance() takes two strings and an optional
     # argument. The optional argument specifies which algorithm should
     # be used to calculate the distance between the two strings.
     # Here we pass in 0 to use the Levenshtein distance.
@@ -117,7 +117,7 @@ class DeviseRecognisable::Guard
       failures[:failures][:user_agent] = {
         request_value: @request.user_agent,
         session_value: @closest_match[:session].user_agent,
-        # DamerauLevenshtein.distance() takes two strings and a optional
+        # DamerauLevenshtein.distance() takes two strings and an optional
         # argument. The optional argument specifies which algorithm should
         # be used to calculate the distance between the two strings.
         # Here we pass in 0 to use the Levenshtein distance.

--- a/app/lib/devise_recognisable/guard.rb
+++ b/app/lib/devise_recognisable/guard.rb
@@ -8,9 +8,9 @@ class DeviseRecognisable::Guard
   MAX_LEVENSHTEIN_DISTANCE = Rails.env.test? ? 10 : 0
 
   @@required_scores = {
-    relaxed: 0,
-    normal: 1,
-    strict: 2
+    relaxed: 2,
+    normal: 3,
+    strict: 4
   }
 
   def self.with(previous_sessions)
@@ -49,7 +49,11 @@ class DeviseRecognisable::Guard
 
     # Is the requests's IP different to the session's?
     # Is it more than a certain distance from the session's IP address?
-    score += 1 if compare_ip_addresses(session.sign_in_ip)
+    case compare_ip_addresses(session.sign_in_ip)
+    when :exact_match then score += 3
+    when :network_match then score += 2
+    when :within_distance then score += 1
+    end
 
     # Is the request's User Agent different to the session's sign in?
     score += 1 if compare_user_agents(session.user_agent)
@@ -61,19 +65,27 @@ class DeviseRecognisable::Guard
   end
 
   # Method to check if the ip addresses are similar. Takes a session_address
-  # and returns a bool
+  # and returns a :symbol for the level of similarity.
   def compare_ip_addresses(session_address)
-    return true if session_address == @request.location.ip
-    
+    # Check if the IP is an exact match
+    return :exact_match if session_address == @request.location.ip
+
+    # Check if the IP network octets match
+    session_network = network_octets(session_address)
+    request_network = network_octets(@request.location.ip)
+    return :network_match if session_network == request_network
+
+    # Check if the request IP is within the max_ip_distance from a previous IP
     # NOTE: Geocoder's location method might not be the safest?
     # See https://github.com/alexreisner/geocoder#geocoding-http-requests
     previous_sign_in = Geocoder.search(session_address).first
     current_sign_in = Geocoder.search(@request.location.ip).first
-    
     # NOTE: looks like sometimes the current_sign_in isn't a real thing?
     distance = Geocoder::Calculations.distance_between(previous_sign_in&.coordinates, current_sign_in&.coordinates)
-    
-    distance < Devise.max_ip_distance
+    return :within_distance if distance < Devise.max_ip_distance
+
+    # If the request IP does not pass any of the comparisons,
+    return :complete_mismatch
   end
 
   # Method to check if the user agent strings are similar. Uses the Levenshtein
@@ -105,10 +117,12 @@ class DeviseRecognisable::Guard
 
     # Is the requests's IP different to the session's?
     # Is it more than a certain distance from the session's IP address?
-    unless compare_ip_addresses(@closest_match[:session].sign_in_ip)
+    ip_comparison_result = compare_ip_addresses(@closest_match[:session].sign_in_ip)
+    unless ip_comparison_result == :exact_match
       failures[:failures][:ip_address] = {
         request_value: @request.location.ip,
-        session_value: @closest_match[:session].sign_in_ip
+        session_value: @closest_match[:session].sign_in_ip,
+        comparison_result: ip_comparison_result
       }
     end
 
@@ -140,4 +154,25 @@ class DeviseRecognisable::Guard
     return failures
   end
 
+  private
+
+  # Extract the Network octets from an IP. Takes an IP address and returns
+  # an array of the octets. The network octets vary in number between different
+  # IP classes. You can determine the class by looking at the value of the
+  # left most octet.
+  # http://penta2.ufrgs.br/trouble/ts_ip.htm#First-Octet%20Rule
+  CLASS_A_UPPER_LIMIT = 126
+  CLASS_B_UPPER_LIMIT = 191
+  def network_octets(ip_address)
+    octets = ip_address.split('.')
+
+    left_most_octet = octets[0].to_i
+    if left_most_octet <= CLASS_A_UPPER_LIMIT
+      network_octets = [octets[0]]
+    elsif left_most_octet <= CLASS_B_UPPER_LIMIT
+      network_octets = octets[0..1]
+    else
+      network_octets = octets[0..2]
+    end
+  end
 end

--- a/app/lib/devise_recognisable/guard.rb
+++ b/app/lib/devise_recognisable/guard.rb
@@ -70,6 +70,12 @@ class DeviseRecognisable::Guard
     # Check if the IP is an exact match
     return :exact_match if session_address == @request.location.ip
 
+    # Check that neither IP address is IPv6.
+    # If either is, return :ip_version_mismatch.
+    if ipv6?(@request.location.ip) || ipv6?(session_address)
+      return :ip_version_mismatch
+    end
+
     # Check if the IP network octets match
     session_network = network_octets(session_address)
     request_network = network_octets(@request.location.ip)
@@ -174,5 +180,9 @@ class DeviseRecognisable::Guard
     else
       network_octets = octets[0..2]
     end
+  end
+
+  def ipv6?(ip_address)
+    ip_address.include? ':'
   end
 end

--- a/app/lib/devise_recognisable/guard.rb
+++ b/app/lib/devise_recognisable/guard.rb
@@ -71,9 +71,9 @@ class DeviseRecognisable::Guard
     return :exact_match if session_address == @request.location.ip
 
     # Check that neither IP address is IPv6.
-    # If either is, return :ip_version_mismatch.
+    # If either is, return :complete_mismatch.
     if ipv6?(@request.location.ip) || ipv6?(session_address)
-      return :ip_version_mismatch
+      return :complete_mismatch
     end
 
     # Check if the IP network octets match

--- a/spec/dummy-app/Gemfile
+++ b/spec/dummy-app/Gemfile
@@ -59,7 +59,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'ffaker'
+  gem 'faker'
   gem 'factory_bot_rails'
   gem 'email_spec'
 end

--- a/spec/dummy-app/Gemfile.lock
+++ b/spec/dummy-app/Gemfile.lock
@@ -90,7 +90,8 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    ffaker (2.17.0)
+    faker (2.14.0)
+      i18n (>= 1.6, < 2)
     ffi (1.13.1)
     geocoder (1.6.4)
     globalid (0.4.2)
@@ -238,7 +239,7 @@ DEPENDENCIES
   devise-recognisable!
   email_spec
   factory_bot_rails
-  ffaker
+  faker
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   puma (~> 4.3)

--- a/spec/dummy-app/spec/factories/user.rb
+++ b/spec/dummy-app/spec/factories/user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    email { FFaker::Internet.email }
-    password { FFaker::Internet.password }
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
   end
 end
 

--- a/spec/dummy-app/spec/features/sign_in_spec.rb
+++ b/spec/dummy-app/spec/features/sign_in_spec.rb
@@ -120,12 +120,16 @@ RSpec.feature "Sign in" do
 
       it 'sends a debug message to Rollbar' do
         expect(Rollbar).to receive(:debug)
-        .with(hash_including(
-          :failures=> {:ip_address=>{:request_value=>"127.0.0.1", :session_value=>new_ip}},
-          :score=>2,
-          :user_id=>1,
-          :user_type=>"User"
-          ), "Unrecognised request")
+          .with(hash_including(
+            :failures=> {:ip_address=>{
+              :request_value=>"127.0.0.1",
+              :session_value=>new_ip,
+              :comparison_result=>:complete_mismatch
+            }},
+            :score=>2,
+            :user_id=>1,
+            :user_type=>"User"
+            ), "Unrecognised request")
         visit '/'
         click_link 'Log in'
         fill_in 'Email', with: user.email
@@ -160,12 +164,16 @@ RSpec.feature "Sign in" do
 
       it 'sends a debug message to Rollbar' do
         expect(Rollbar).to receive(:debug)
-        .with(hash_including(
-          :failures=> {:ip_address=>{:request_value=>"127.0.0.1", :session_value=>new_ip}},
-          :score=>2,
-          :user_id=>1,
-          :user_type=>"User"
-          ), "Unrecognised request")
+          .with(hash_including(
+            :failures=> {:ip_address=>{
+              :request_value=>"127.0.0.1",
+              :session_value=>new_ip,
+              :comparison_result=>:complete_mismatch
+            }},
+            :score=>2,
+            :user_id=>1,
+            :user_type=>"User"
+            ), "Unrecognised request")
         visit '/'
         click_link 'Log in'
         fill_in 'Email', with: user.email

--- a/spec/dummy-app/spec/features/sign_in_spec.rb
+++ b/spec/dummy-app/spec/features/sign_in_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature "Sign in" do
-  let(:email) { FFaker::Internet.email }
-  let(:password) { FFaker::Internet.password }
+  let(:email) { Faker::Internet.email }
+  let(:password) { Faker::Internet.password }
   let!(:user) { FactoryBot.create :user }
 
   let!(:user_agent) { 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36' }
@@ -70,7 +70,7 @@ RSpec.feature "Sign in" do
         visit '/'
         click_link 'Log in'
         fill_in 'Email', with: email
-        fill_in 'Password', with: FFaker::Internet.password
+        fill_in 'Password', with: Faker::Internet.password
         click_button 'Log in'
       }.not_to change { DeviseRecognisable::RecognisableSession.count }
     end
@@ -80,38 +80,71 @@ RSpec.feature "Sign in" do
     let!(:recognisable_session) { FactoryBot.create :recognisable_session, recognisable_session_values }
 
     context 'with Devise.debug_mode set to false' do
-      before do
-        recognisable_session.update(sign_in_ip: FFaker::Internet.ip_v4_address)
-        visit '/'
-        click_link 'Log in'
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: user.password
-        click_button 'Log in'
-      end
-
-      it 'does not log the user in' do
-        expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
-        expect(page).to_not have_content('Home sweet home')
-      end
-
-      context 'visiting the link in the email' do
-        it 'logs the user in' do
-          open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
-          visit_in_email('Log in')
-          expect(page).to have_content('Home sweet home')
+      context 'if the ip addresses are of the same IP version' do
+        before do
+          recognisable_session.update(sign_in_ip: Faker::Internet.ip_v4_address)
+          visit '/'
+          click_link 'Log in'
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: user.password
+          click_button 'Log in'
         end
 
-        it 'creates a new DeviseRecognisable::RecognisableSession on sucessfull sign in' do
-          expect {
+        it 'does not log the user in' do
+          expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
+          expect(page).to_not have_content('Home sweet home')
+        end
+
+        context 'visiting the link in the email' do
+          it 'logs the user in' do
             open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
             visit_in_email('Log in')
-          }.to change { DeviseRecognisable::RecognisableSession.count }.from(1).to(2)
+            expect(page).to have_content('Home sweet home')
+          end
+
+          it 'creates a new DeviseRecognisable::RecognisableSession on sucessfull sign in' do
+            expect {
+              open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
+              visit_in_email('Log in')
+            }.to change { DeviseRecognisable::RecognisableSession.count }.from(1).to(2)
+          end
+        end
+      end
+
+      context 'if the ip addresses are of different IP versions' do
+        before do
+          recognisable_session.update(sign_in_ip: Faker::Internet.ip_v6_address)
+          visit '/'
+          click_link 'Log in'
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: user.password
+          click_button 'Log in'
+        end
+
+        it 'does not log the user in' do
+          expect(page).to have_content I18n.t('devise.sessions.send_new_ip_instructions')
+          expect(page).to_not have_content('Home sweet home')
+        end
+
+        context 'visiting the link in the email' do
+          it 'logs the user in' do
+            open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
+            visit_in_email('Log in')
+            expect(page).to have_content('Home sweet home')
+          end
+
+          it 'creates a new DeviseRecognisable::RecognisableSession on sucessfull sign in' do
+            expect {
+              open_email(user.email, with_subject: I18n.t('devise.mailer.new_ip.subject'))
+              visit_in_email('Log in')
+            }.to change { DeviseRecognisable::RecognisableSession.count }.from(1).to(2)
+          end
         end
       end
     end
 
     context 'with Devise.debug_mode set to true' do
-      let!(:new_ip) { FFaker::Internet.ip_v4_address }
+      let!(:new_ip) { Faker::Internet.ip_v4_address }
       before do
         Devise.debug_mode = true
         Rails.env = 'production'
@@ -144,7 +177,7 @@ RSpec.feature "Sign in" do
     end
 
     context 'with Devise.info_only set to true' do
-      let!(:new_ip) { FFaker::Internet.ip_v4_address }
+      let!(:new_ip) { Faker::Internet.ip_v4_address }
       before do
         Devise.info_only = true
         Rails.env = 'production'

--- a/spec/dummy-app/spec/lib/devise_recognisable/guard_spec.rb
+++ b/spec/dummy-app/spec/lib/devise_recognisable/guard_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+require 'geocoder'
+
+RSpec.describe DeviseRecognisable::Guard do
+  let(:mock_session) { double("MockPreviousSession", :sign_in_ip => "106.114.4.175") }
+  let(:mock_request) { double("MockRequest", :location => mock_geocode_location) }
+  let(:guard) { described_class.new([mock_session]) }
+  
+  context "#compare_ip_addresses" do
+    before do
+      # This is a little odd, but all we want to assign the mock_request to
+      # Guard's @request.
+      allow(guard).to receive(:calculate_score_for).and_return(0)
+      guard.recognise?(mock_request)
+    end
+
+    context 'if the ip addresses are identical' do
+      let(:mock_geocode_location) { double("MockGeocodeLocation", :ip => "106.114.4.175") }
+      it 'returns :exact_match' do
+        expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :exact_match
+      end
+    end
+
+    context 'if only the ip addresses host octets are different' do
+      let(:mock_geocode_location) { double("MockGeocodeLocation", :ip => "106.114.77.88") }
+      it 'returns :network_match' do
+        expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :network_match
+      end
+    end
+
+    context 'if the ip addresses are within the configuarble distance of each other' do
+      let(:mock_geocode_location) { double("MockGeocodeLocation", :ip => "200.200.200.200") }
+      it 'returns :within_distance' do
+        allow(Geocoder::Calculations).to receive(:distance_between)
+          .and_return(Devise.max_ip_distance - 1)
+        expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :within_distance
+      end
+    end
+
+    context 'if the ip addresses are completly different' do
+      let(:mock_geocode_location) { double("MockGeocodeLocation", :ip => "40.100.100.100") }
+      it 'returns :within_distance' do
+        expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :complete_mismatch
+      end
+    end
+  end
+end

--- a/spec/dummy-app/spec/lib/devise_recognisable/guard_spec.rb
+++ b/spec/dummy-app/spec/lib/devise_recognisable/guard_spec.rb
@@ -37,10 +37,17 @@ RSpec.describe DeviseRecognisable::Guard do
       end
     end
 
-    context 'if the ip addresses are completly different' do
+    context 'if the ip addresses are completely different' do
       let(:mock_geocode_location) { double("MockGeocodeLocation", :ip => "40.100.100.100") }
       it 'returns :within_distance' do
         expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :complete_mismatch
+      end
+    end
+
+    context 'if either ip address is IPv6' do
+      let(:mock_geocode_location) { double("MockGeocodeLocation", :ip => "2001:0db8:0000:0000:0000:ff00:0042:8329") }
+      it 'returns :within_distance' do
+        expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :ip_version_mismatch
       end
     end
   end

--- a/spec/dummy-app/spec/lib/devise_recognisable/guard_spec.rb
+++ b/spec/dummy-app/spec/lib/devise_recognisable/guard_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe DeviseRecognisable::Guard do
       end
     end
 
-    context 'if either ip address is IPv6' do
+    context 'if one of the ip address is IPv6' do
       let(:mock_geocode_location) { double("MockGeocodeLocation", :ip => "2001:0db8:0000:0000:0000:ff00:0042:8329") }
       it 'returns :within_distance' do
-        expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :ip_version_mismatch
+        expect(guard.compare_ip_addresses(mock_session.sign_in_ip)).to eq :complete_mismatch
       end
     end
   end


### PR DESCRIPTION
This PR changes how we compare IP addresses.
1. Check the IP addresses aren't an exact match --> if they are, we can return and award 3 points.
2. Check the IP addresses' Network Octets aren't a match --> if they are, we can return and award 2 points.
3. Check the IP addresses are within the `max_ip_distance` of each other --> if they are, we can return and award 1 point.
4. If the IP addresses are completely different, we award no points.

Re: the `#failures` debug method:
Unless the IP addresses are an exact match, we log the IP addresses and the `comparison_result` to Rollbar.