### PR TITLE
Add a PR template to encourage contributors to include all the releva…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Changes
+*Description of what changes you made.*
+
+*Provide any additional context needed to understand the PR.*
+
+## Ticket
+*Insert link to Github project here*
+
+## Before submitting have you:
+
+- [ ] Included a link to any relevant ticket
+- [ ] Included links to any github issues
+- [ ] Prefix the title with the PR type (Feature, Bugfix, Documentation, Chore)
+
+## After submitting remember to:
+
+- [ ] Mark the ticket as ready for review
+- [ ] Include the PR on the ticket
+- [ ] Assign a single reviewer


### PR DESCRIPTION
## Changes
We're reviewing Pixie Labs OSS. As part of that work, we want to encourage contributors to include all the info needed to review their pull requests.

## Ticket
https://github.com/orgs/pixielabs/projects/4/views/1?pane=issue&itemId=32152031

## Before submitting have you:

- [ ] Included a link to any relevant ticket
- [ ] Included links to any github issues
- [ ] Prefix the title with the PR type (Feature, Bugfix, Documentation, Chore)

## After submitting remember to:

- [ ] Mark the ticket as ready for review
- [ ] Include the PR on the ticket
- [ ] Assign a single reviewer