### PR TITLE
Bugfix/store recognisable session on registration

### DIFF
--- a/app/controllers/devise_recognisable/registrations_controller.rb
+++ b/app/controllers/devise_recognisable/registrations_controller.rb
@@ -1,0 +1,17 @@
+
+class DeviseRecognisable::RegistrationsController < Devise::RegistrationsController
+  append_after_action :store_recognisable_details, only: :create
+
+  # After the user has been signed up, we save the ip address in the
+  # DeviseRecognisable::RecognisableSession table.
+  def store_recognisable_details
+    return unless resource.persisted?
+    DeviseRecognisable::RecognisableSession.create!(
+      recognisable: resource_class.find_by(email: params[resource_name][:email]),
+      sign_in_ip: request.location.ip,
+      sign_in_at: Time.now,
+      user_agent: request.user_agent,
+      accept_header: request.headers["HTTP_ACCEPT"]
+    )
+  end
+end

--- a/lib/devise-recognisable/mapping.rb
+++ b/lib/devise-recognisable/mapping.rb
@@ -7,6 +7,7 @@ module DeviseRecognisable
       options[:controllers] ||= {}
       # Use our SessionsController instead of Devise's.
       options[:controllers][:sessions] ||= 'devise_recognisable/sessions'
+      options[:controllers][:registrations] ||= 'devise_recognisable/registrations'
       super
     end
 

--- a/spec/dummy-app/spec/features/sign_in_spec.rb
+++ b/spec/dummy-app/spec/features/sign_in_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Sign in" do
         fill_in 'Email', with: email
         fill_in 'Password', with: password
         click_button 'Log in'
-      }.to change { DeviseRecognisable::RecognisableSession.count }.from(0).to(1)
+      }.to change { DeviseRecognisable::RecognisableSession.count }.from(1).to(2)
     end
 
     it "doesn't create a new DeviseRecognisable::RecognisableSession on unsuccessful sign in" do

--- a/spec/dummy-app/spec/features/sign_up_spec.rb
+++ b/spec/dummy-app/spec/features/sign_up_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.feature "Sign in" do
+  let(:email) { Faker::Internet.email }
+  let(:password) { Faker::Internet.password }
+
+  let!(:user_agent) { 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36' }
+  let!(:accept_header) { 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' }
+  # let!(:recognisable_session_values) {{
+  #   recognisable_id: user.id,
+  #   recognisable_type: 'User',
+  #   user_agent: user_agent,
+  #   accept_header: accept_header
+  # }}
+
+  before do
+    Capybara.current_session.driver.header('User-Agent', user_agent)
+    Capybara.current_session.driver.header('Accept', accept_header)
+  end
+
+  context 'as a new user' do
+    it 'creates a devise recognisable session' do
+      visit '/'
+      expect(page).to have_content 'Welcome to my website'
+      click_link 'Log in'
+      click_link 'Sign up'
+      fill_in 'Email', with: email
+      fill_in 'Password', with: password
+      fill_in 'Password confirmation', with: password
+      expect {
+        click_button 'Sign up'
+      }.to change(DeviseRecognisable::RecognisableSession, :count).by(1)
+      expect(page).to have_content 'Welcome!'
+      expect(page).to have_content('signed up successfully')
+    end
+  end
+end

--- a/spec/dummy-app/spec/features/sign_up_spec.rb
+++ b/spec/dummy-app/spec/features/sign_up_spec.rb
@@ -4,20 +4,6 @@ RSpec.feature "Sign in" do
   let(:email) { Faker::Internet.email }
   let(:password) { Faker::Internet.password }
 
-  let!(:user_agent) { 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36' }
-  let!(:accept_header) { 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' }
-  # let!(:recognisable_session_values) {{
-  #   recognisable_id: user.id,
-  #   recognisable_type: 'User',
-  #   user_agent: user_agent,
-  #   accept_header: accept_header
-  # }}
-
-  before do
-    Capybara.current_session.driver.header('User-Agent', user_agent)
-    Capybara.current_session.driver.header('Accept', accept_header)
-  end
-
   context 'as a new user' do
     it 'creates a devise recognisable session' do
       visit '/'


### PR DESCRIPTION
## Changes
Stores a recognisable session on registration

I noticed that sessions aren't stored when a user first registers, so the first actual sign in works without hitting Guard

I'm not particularly comfortable with this change, so let me know if it has some horrid gotchas i'm not aware of 😛 

## Ticket
https://github.com/pixielabs/devise-recognisable/issues/105

## Before submitting have you:

- [ ] Included a link to any relevant ticket
- [ ] Included links to any github issues
- [ ] Prefix the title with the PR type (Feature, Bugfix, Documentation, Chore)

## After submitting remember to:

- [ ] Mark the ticket as ready for review
- [ ] Include the PR on the ticket
- [ ] Assign a single reviewer