### PR TITLE
Configure RSpec --only-failures flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# Ignore the file recording test run statuses.
+spec/dummy-app/spec/examples.txt

--- a/spec/dummy-app/.gitignore
+++ b/spec/dummy-app/.gitignore
@@ -33,3 +33,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore the file recording test run statuses.
+/spec/example.txt

--- a/spec/dummy-app/spec/spec_helper.rb
+++ b/spec/dummy-app/spec/spec_helper.rb
@@ -44,6 +44,11 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
@@ -54,10 +59,7 @@ RSpec.configure do |config|
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
 
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:


### PR DESCRIPTION
## Changes
- Configure rspec's --only-failures flag

- This config stores information about passing/failing tests in examples.txt and allows to run:
  - `rspec --only-failures` (that only runs the failed tests from the previous run)
  - `rspec --next-failure` (that runs the next failed test from the previous run)

*Provide any additional context needed to understand the PR.*

## Ticket
N/A

## Before submitting have you:

- [ ] Included a link to any relevant ticket
- [ ] Included links to any github issues
- [ ] Prefix the title with the PR type (Feature, Bugfix, Documentation, Chore)

## After submitting remember to:

- [ ] Mark the ticket as ready for review
- [ ] Include the PR on the ticket
- [ ] Assign a single reviewer